### PR TITLE
fix(tsconfig): adjust composite and declaration settings for improved type checking

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -7,7 +7,7 @@
         "build": "vite build",
         "clean": "git clean -xdf .cache .turbo .wrangler dist node_modules",
         "dev": "vite --host 0.0.0.0 --port 8787",
-        "deploy": "wrangler deploy --minify",
+        "deploy": "wrangler deploy",
         "cf-typegen": "wrangler types --env-interface CloudflareBindings"
     },
     "dependencies": {

--- a/apps/hono/wrangler.jsonc
+++ b/apps/hono/wrangler.jsonc
@@ -3,7 +3,7 @@
  * https://developers.cloudflare.com/workers/wrangler/configuration/
  */
 {
-	"$schema": "node_modules/wrangler/config-schema.json",
+	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "veth-api",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-07-19",

--- a/apps/vite/tsconfig.json
+++ b/apps/vite/tsconfig.json
@@ -5,6 +5,9 @@
   ],
   "compilerOptions": {
     "jsx": "react-jsx",
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
     "types": [
       "vite/client"
     ],

--- a/tooling/typescript/base.json
+++ b/tooling/typescript/base.json
@@ -2,12 +2,11 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "composite": false,
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "emitDeclarationOnly": true,
     "incremental": true,
     "inlineSources": false,
     "isolatedModules": true,


### PR DESCRIPTION
fixing these errors

```
> tsc && vite build

src/utils/trpc-client.ts:45:14 - error TS2742: The inferred type of 'createTrpcClient' cannot be named wit
hout a reference to '../../node_modules/@repo/api/dist/lib/trpc'. This is likely not portable. A type anno
tation is necessary.

45 export const createTrpcClient = () =>
                ~~~~~~~~~~~~~~~~

src/utils/trpc-client.ts:61:16 - error TS2742: The inferred type of 'TRPCProvider' cannot be named without
 a reference to '../../node_modules/@repo/api/dist/lib/trpc'. This is likely not portable. A type annotati
on is necessary.

61 export const { TRPCProvider, useTRPC, useTRPCClient } =
                  ~~~~~~~~~~~~

src/utils/trpc-client.ts:61:30 - error TS2742: The inferred type of 'useTRPC' cannot be named without a re
ference to '../../node_modules/@repo/api/dist/lib/trpc'. This is likely not portable. A type annotation is
 necessary.

61 export const { TRPCProvider, useTRPC, useTRPCClient } =
                                ~~~~~~~

src/utils/trpc-client.ts:61:39 - error TS2742: The inferred type of 'useTRPCClient' cannot be named withou
t a reference to '../../node_modules/@repo/api/dist/lib/trpc'. This is likely not portable. A type annotat
ion is necessary.

61 export const { TRPCProvider, useTRPC, useTRPCClient } =
                                         ~~~~~~~~~~~~~


Found 4 errors in the same file, starting at: src/utils/trpc-client.ts:45

 ELIFECYCLE  Command failed with exit code 2.
command finished with error: command (/Users/waptik/code/waptik/woym-monorepo/apps/vite) /Users/waptik/.nv
m/versions/node/v22.17.1/bin/pnpm run build exited (2)
└─ @repo/vite#build ──
@repo/vite#build: command (/Users/waptik/code/waptik/woym-monorepo/apps/vite) /Users/waptik/.nvm/versions/node/v22.17.1/bin/pnpm run build exited (2)

 Tasks:    3 successful, 5 total
Cached:    0 cached, 5 total
  Time:    8.247s 
Failed:    @repo/vite#build

 ERROR  run failed: command  exited (2)
 ELIFECYCLE  Command failed with exit code 2.


```